### PR TITLE
Bug fixed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := "spark-lenses"
+name := "spark-optics"
 
 version := "0.1"
 


### PR DESCRIPTION
In a composed lens, the first level had a non empty previous level
Changed the name of the project to spark-optics.